### PR TITLE
Added libffi-dev to list of required apt-get packages

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -108,7 +108,7 @@ if [ "$?" -ne 0 ]; then echo "[!] Failed :("; exit 1; fi
 echo "[+] Installing required packages..."
 sleep 3
 
-apt-get install -y python-pip gcc libxml2-dev libxslt-dev python2.7-dev mysql-server squid3 openvpn bind9 tshark python-mysqldb apache2 python-beaker python-flask python-jinja2 python-mysqldb python-sqlalchemy python-werkzeug
+apt-get install -y libffi-dev python-pip gcc libxml2-dev libxslt-dev python2.7-dev mysql-server squid3 openvpn bind9 tshark python-mysqldb apache2 python-beaker python-flask python-jinja2 python-mysqldb python-sqlalchemy python-werkzeug
 if [ "$?" -ne 0 ]; then echo "[!] Failed :("; exit 1; fi
 if [ "$xplico" == "yes" ]; then
 	apt-get install -y xplico 


### PR DESCRIPTION
Script failed during pip installs due to missing "ffi.h" file that is included with "libffi-dev" so I added this to the required packages.
